### PR TITLE
exclude all the files that end with ".meta" when executing the PostprocessBuildPlayer_ scripts

### DIFF
--- a/source/Editor/PostprocessBuildPlayer
+++ b/source/Editor/PostprocessBuildPlayer
@@ -4,7 +4,7 @@
 #Must follow naming convention PostprocessBuildPlayer_* and be kept in the Assets/Editor folder.
 
 echo "Running post-process build scripts."
-for script in `/bin/ls -1 Assets/Editor | grep -i ^postprocessbuildplayer_`; do
+for script in `/bin/ls -1 Assets/Editor | grep -i ^postprocessbuildplayer_ | grep -v [.]meta$`; do
     chmod +x "Assets/Editor/$script"
     echo "[[[ $script ]]]"
     "Assets/Editor/$script" "$@"


### PR DESCRIPTION
since the release of unity 4.3 meta files are created by default, this commit exclude all the files that end with ".meta" when executing the PostprocessBuildPlayer_ scripts
