### PR TITLE
Support Unity 5+ instead of only Unity 5.0

### DIFF
--- a/source/Plugins/GoogleAnalyticsV3/GoogleAnalyticsV3.cs
+++ b/source/Plugins/GoogleAnalyticsV3/GoogleAnalyticsV3.cs
@@ -118,7 +118,7 @@ public class GoogleAnalyticsV3 : MonoBehaviour {
     }
 
     if (UncaughtExceptionReporting) {
-#if UNITY_5_0
+#if UNITY_5
       Application.logMessageReceived += HandleException;
 #else
       Application.RegisterLogCallback (HandleException);


### PR DESCRIPTION
The old file checked specifically for Unity 5.0 to use the new api, but now that 5.1 and soon 5.2 are released the check needs to be improved. 

This define only checks the major version, so it should work until Unity 6 is released.