### PR TITLE
Add definition for user agent override field.

### DIFF
--- a/source/Plugins/GoogleAnalyticsV3/Fields.cs
+++ b/source/Plugins/GoogleAnalyticsV3/Fields.cs
@@ -40,6 +40,7 @@ public class Fields {
   public readonly static Field SCREEN_COLORS = new Field("&sd");
   public readonly static Field SCREEN_RESOLUTION = new Field("&sr");
   public readonly static Field VIEWPORT_SIZE = new Field("&vp");
+  public readonly static Field USER_AGENT_OVERRIDE = new Field("&ua");
 
   // Application
   public readonly static Field APP_NAME = new Field("&an");


### PR DESCRIPTION
use case:  allows apps to override user agent, notably used with SetOnTracker so that all hits contain OS information and thereby the stock OS tracking reporting of Analytics can be utilized

(Aside: I have an implementation of the user agent string synthesis which I could contribute to the library.  Coverage is partial at this point, supporting Windows and Mac.)
