### PR TITLE
Add FlushRequests method

### DIFF
--- a/source/Plugins/GoogleAnalyticsV3/GoogleAnalyticsV3.cs
+++ b/source/Plugins/GoogleAnalyticsV3/GoogleAnalyticsV3.cs
@@ -492,4 +492,17 @@ public void DispatchHits() {
   public static GoogleAnalyticsV3 getInstance() {
     return instance;
   }
+
+  // Block on completion of any pending requests, returning true if all
+  // requests completed (either succeeding or failing) within the given timeout.
+  // Intended to be called from OnApplicationQuit hook.
+  public bool FlushRequests(int timeoutMilliseconds) {
+    #if UNITY_ANDROID && !UNITY_EDITOR
+    return true;
+    #elif UNITY_IPHONE && !UNITY_EDITOR
+    return true;
+    #else
+    return mpTracker.FlushRequests(timeoutMilliseconds);
+    #endif
+  }
 }


### PR DESCRIPTION
use case:  allows apps to ensure pending HTTP requests are sent before closing.  Especially useful for apps wanting to log events at ApplicationQuit time.
