### PR TITLE
Unity API compat: Check against v5.x rather than v5.0

### DIFF
--- a/source/Plugins/GoogleAnalyticsV4/GoogleAnalyticsV4.cs
+++ b/source/Plugins/GoogleAnalyticsV4/GoogleAnalyticsV4.cs
@@ -119,7 +119,7 @@ public class GoogleAnalyticsV4 : MonoBehaviour {
     }
 
     if (UncaughtExceptionReporting) {
-#if UNITY_5_0
+#if UNITY_5
       Application.logMessageReceived += HandleException;
 #else
       Application.RegisterLogCallback (HandleException);


### PR DESCRIPTION
Current `#if` API compatibility macro is checking against Unity v5.0 strictly, which does not include v5.1, v5.2, etc. This causes warnings on newer Unity versions.

This change makes the check against just the major version v5.x, no more warnings during build.