### PR TITLE
Correcting path and file extensions for libz and libsqlite3

### DIFF
--- a/iOS Extras/PostprocessBuildPlayer_GA
+++ b/iOS Extras/PostprocessBuildPlayer_GA
@@ -10,13 +10,14 @@ frameworks = [
               'AdSupport.framework',
               'CoreData.framework',
               'SystemConfiguration.framework',
-              'libz.dylib',
-              'libsqlite3.dylib'
               ]
 
+libs = 		  [
+			  'libz.tbd',
+			  'libsqlite3.tbd'
+			  ]
+
 framework_dir = path.join(sys.argv[0],'..','..','Plugins','iOS')
-
-
 
 pbx_file_path = sys.argv[1] + '/Unity-iPhone.xcodeproj/project.pbxproj'
 pbx_object = XcodeProject.Load(pbx_file_path)
@@ -24,6 +25,9 @@ pbx_object = XcodeProject.Load(pbx_file_path)
 pbx_object.add_framework_search_paths([path.abspath(framework_dir)])
 
 for framework in frameworks:
-    pbx_object.add_file('System/Library/' + framework, tree='SDKROOT')
+    pbx_object.add_file('System/Library/Frameworks/' + framework, tree='SDKROOT')
+
+for lib in libs:
+    pbx_object.add_file('usr/lib/' + lib, tree='SDKROOT')
 
 pbx_object.save()


### PR DESCRIPTION
Similar pull request to the following:

https://github.com/googleanalytics/google-analytics-plugin-for-unity/pull/67/files

However, this also includes updated file extensions for libz and libsqlite3 which have changed from .dylib to .tbd in XCode 7.3