### PR TITLE
Added Platform Dependent Compilation directive to GADependencies.cs

### DIFF
--- a/source/PlayServicesResolver/Editor/GADependencies.cs
+++ b/source/PlayServicesResolver/Editor/GADependencies.cs
@@ -1,4 +1,6 @@
-﻿using Google.JarResolver;
+#if UNITY_ANDROID
+
+using Google.JarResolver;
 using UnityEditor;
 
 [InitializeOnLoad]
@@ -22,3 +24,5 @@ public static class GADependencies
         svcSupport.DependOn("com.google.android.gms", "play-services-analytics", "9.4");
     }
 }
+
+#endif


### PR DESCRIPTION
PlayServicesResolver scripts are only required on Android.
Added Platform Dependent Compilation directive to GADependencies.cs that has been missed.
Stops error `Google.JarResolver.ResolutionException: Cannot find candidate artifact for com.google.android.gms:play-services-analytics:9.4` being logged out on other target platforms.
