### PR TITLE
Unity 5.x vs Unity 2017.x preprocessor directive.

### DIFF
--- a/source/Plugins/GoogleAnalyticsV4/GoogleAnalyticsV4.cs
+++ b/source/Plugins/GoogleAnalyticsV4/GoogleAnalyticsV4.cs
@@ -119,7 +119,7 @@ public class GoogleAnalyticsV4 : MonoBehaviour {
     }
 
     if (UncaughtExceptionReporting) {
-#if UNITY_5
+#if UNITY_5 || UNITY_2017
       Application.logMessageReceived += HandleException;
 #else
       Application.RegisterLogCallback (HandleException);
@@ -150,7 +150,7 @@ public class GoogleAnalyticsV4 : MonoBehaviour {
       instance = this;
 
       DontDestroyOnLoad(instance);
-      
+
       // automatically set app parameters from player settings if they are left empty
       if(string.IsNullOrEmpty(productName)) {
         productName = Application.productName;


### PR DESCRIPTION
Unfortunately, `#if UNITY_5_OR_NEWER` does not work. I've submitted a [bug report](https://fogbugz.unity3d.com/default.asp?934873_bj2augo1qols48rb) to Unity so that it will get addressed.
