### PR TITLE
Fixed NullReferenceException thrown on WWW error.

### DIFF
--- a/source/Plugins/GoogleAnalyticsV4/GoogleAnalyticsMPV3.cs
+++ b/source/Plugins/GoogleAnalyticsV4/GoogleAnalyticsMPV3.cs
@@ -151,7 +151,7 @@ public class GoogleAnalyticsMPV3 {
     while (!request.isDone)
     {
       yield return request;
-      if (request.responseHeaders.ContainsKey("STATUS")) {
+      if (request.responseHeaders != null && request.responseHeaders.ContainsKey("STATUS")) {
         if (request.responseHeaders["STATUS"].Contains("200 OK")) {
           if (GoogleAnalyticsV4.belowThreshold(logLevel, GoogleAnalyticsV4.DebugMode.INFO)) {
             Debug.Log("Successfully sent Google Analytics hit.");


### PR DESCRIPTION
Added a null check to the code that handles the WWW response, so that if the responseHeaders property is null for any reason (e.g. a network error occurred), then the coroutine logs a warning, rather than throwing a NullReferenceException. This fixes #160 .